### PR TITLE
Futures account api

### DIFF
--- a/src/api.rs
+++ b/src/api.rs
@@ -72,6 +72,7 @@ pub enum Futures {
     TakerlongshortRatio,
     LvtKlines,
     IndexInfo,
+    ChangeInitialLeverage,
 }
 
 impl From<API> for String {
@@ -134,6 +135,7 @@ impl From<API> for String {
                     Futures::TakerlongshortRatio => "/futures/data/takerlongshortRatio",
                     Futures::LvtKlines => "/fapi/v1/lvtKlines",
                     Futures::IndexInfo => "/fapi/v1/indexInfo",
+                    Futures::ChangeInitialLeverage => "/fapi/v1/leverage",
                 }
             }
         })

--- a/src/api.rs
+++ b/src/api.rs
@@ -7,7 +7,6 @@ use crate::futures::market::*;
 use crate::general::*;
 use crate::market::*;
 use crate::userstream::*;
-use crate::client::*;
 
 #[allow(clippy::all)]
 pub enum API {

--- a/src/futures/account.rs
+++ b/src/futures/account.rs
@@ -292,28 +292,3 @@ impl FuturesAccount {
             .map(|_| ())
     }
 }
-
-#[cfg(test)]
-mod tests {
-    use crate::api::Binance;
-    use crate::errors::Result;
-    use crate::futures::account::FuturesAccount;
-
-    #[test]
-    fn cancel_all_open_orders_test() -> Result<()> {
-        let api_key = Some(String::from(""));
-        let secret_key = Some(String::from(""));
-
-        let account: FuturesAccount = Binance::new(api_key, secret_key);
-        account.cancel_all_open_orders("btcusdt")
-    }
-
-    #[test]
-    fn change_position_mode_test() -> Result<()> {
-        let api_key = Some(String::from(""));
-        let secret_key = Some(String::from(""));
-
-        let account: FuturesAccount = Binance::new(api_key, secret_key);
-        account.change_position_mode(true)
-    }
-}

--- a/src/futures/account.rs
+++ b/src/futures/account.rs
@@ -6,7 +6,7 @@ use crate::client::Client;
 use crate::api::{API, Futures};
 use crate::model::Empty;
 use crate::account::{OrderSide, TimeInForce};
-use super::model::Transaction;
+use super::model::{ChangeLeverageResponse, Transaction};
 
 
 #[derive(Clone)]
@@ -204,6 +204,18 @@ impl FuturesAccount {
         }
 
         parameters
+    }
+
+    pub fn change_initial_leverage<S>(&self, symbol: S, leverage: u8) -> Result<ChangeLeverageResponse>
+    where
+        S: Into<String>
+    {
+        let mut parameters: BTreeMap<String, String> = BTreeMap::new();
+        parameters.insert("symbol".into(), symbol.into());
+        parameters.insert("leverage".into(), leverage.to_string());
+
+        let request = build_signed_request(parameters, self.recv_window)?;
+        self.client.post_signed(API::Futures(Futures::ChangeInitialLeverage), request)
     }
 
     pub fn change_position_mode(&self, dual_side_position: bool) -> Result<()> {

--- a/src/futures/account.rs
+++ b/src/futures/account.rs
@@ -4,8 +4,9 @@ use crate::util::*;
 use crate::errors::*;
 use crate::client::Client;
 use crate::api::{API, Futures};
-use crate::model::{Empty, Order};
+use crate::model::Empty;
 use crate::account::{OrderSide, TimeInForce};
+use super::model::Transaction;
 
 
 #[derive(Clone)]
@@ -113,7 +114,7 @@ impl FuturesAccount {
                      qty: impl Into<f64>,
                      price: f64,
                      time_in_force: TimeInForce,
-    ) -> Result<Order> {
+    ) -> Result<Transaction> {
         let buy = OrderRequest {
             symbol: symbol.into(),
             side: OrderSide::Buy,
@@ -140,7 +141,7 @@ impl FuturesAccount {
                       qty: impl Into<f64>,
                       price: f64,
                       time_in_force: TimeInForce,
-    ) -> Result<Order> {
+    ) -> Result<Transaction> {
         let sell = OrderRequest {
             symbol: symbol.into(),
             side: OrderSide::Sell,
@@ -226,7 +227,7 @@ impl FuturesAccount {
     }
 }
 
-
+#[cfg(test)]
 mod tests {
     use crate::api::Binance;
     use crate::errors::Result;

--- a/src/futures/account.rs
+++ b/src/futures/account.rs
@@ -163,6 +163,60 @@ impl FuturesAccount {
         self.client.post_signed(API::Futures(Futures::Order), request)
     }
 
+    // Place a MARKET order - BUY
+    pub fn market_buy<S, F>(&self, symbol: S, qty: F, time_in_force: TimeInForce) -> Result<Transaction>
+    where
+        S: Into<String>,
+        F: Into<f64>,
+    {
+        let buy = OrderRequest {
+            symbol: symbol.into(),
+            side: OrderSide::Buy,
+            position_side: None,
+            order_type: OrderType::Market,
+            time_in_force: Some(time_in_force),
+            qty: Some(qty.into()),
+            reduce_only: None,
+            price: None,
+            stop_price: None,
+            close_position: None,
+            activation_price: None,
+            callback_rate: None,
+            working_type: None,
+            price_protect: None,
+        };
+        let order = self.build_order(buy);
+        let request = build_signed_request(order, self.recv_window)?;
+        self.client.post_signed(API::Futures(Futures::Order), request)
+    }
+
+    // Place a MARKET order - SELL
+    pub fn market_sell<S, F>(&self, symbol: S, qty: F, time_in_force: TimeInForce) -> Result<Transaction>
+    where
+        S: Into<String>,
+        F: Into<f64>,
+    {
+        let sell: OrderRequest = OrderRequest {
+            symbol: symbol.into(),
+            side: OrderSide::Sell,
+            position_side: None,
+            order_type: OrderType::Market,
+            time_in_force: Some(time_in_force),
+            qty: Some(qty.into()),
+            reduce_only: None,
+            price: None,
+            stop_price: None,
+            close_position: None,
+            activation_price: None,
+            callback_rate: None,
+            working_type: None,
+            price_protect: None,
+        };
+        let order = self.build_order(sell);
+        let request = build_signed_request(order, self.recv_window)?;
+        self.client.post_signed(API::Futures(Futures::Order), request)
+    }
+
     fn build_order(&self, order: OrderRequest) -> BTreeMap<String, String> {
         let mut parameters = BTreeMap::new();
         parameters.insert("symbol".into(), order.symbol);

--- a/src/futures/model.rs
+++ b/src/futures/model.rs
@@ -1,5 +1,5 @@
 use serde::{Deserialize, Serialize};
-use crate::model::string_or_float;
+use crate::model::{string_or_float, string_or_float_opt};
 
 pub use crate::model::{
     Asks, Bids, BookTickers, Filters, KlineSummaries, KlineSummary, RateLimit, ServerTime,
@@ -208,6 +208,44 @@ struct Order {
     pub update_time: u64,
     pub working_type: String,
     pub price_protect: bool,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct Transaction {
+    pub client_order_id: String,
+    #[serde(with = "string_or_float")]
+    pub cum_qty: f64,
+    #[serde(with = "string_or_float")]
+    pub cum_quote: f64,
+    #[serde(with = "string_or_float")]
+    pub executed_qty: f64,
+    pub order_id: u64,
+    #[serde(with = "string_or_float")]
+    pub avg_price: f64,
+    #[serde(with = "string_or_float")]
+    pub orig_qty: f64,
+    pub reduce_only: bool,
+    pub side: String,
+    pub position_side: String,
+    pub status: String,
+    #[serde(with = "string_or_float")]
+    pub stop_price: f64,
+    pub close_position: bool,
+    pub symbol: String,
+    pub time_in_force: String,
+    #[serde(rename = "type")]
+    pub type_name: String,
+    pub orig_type: String,
+    #[serde(default)]
+    #[serde(with = "string_or_float_opt")]
+    pub activate_price: Option<f64>,
+    #[serde(default)]
+    #[serde(with = "string_or_float_opt")]
+    pub price_rate: Option<f64>,
+    pub update_time: u64,
+    pub working_type: String,
+    price_protect: bool,
 }
 
 fn default_stop_price() -> f64 { 0.0 }

--- a/src/futures/model.rs
+++ b/src/futures/model.rs
@@ -248,6 +248,15 @@ pub struct Transaction {
     price_protect: bool,
 }
 
+#[derive(Debug, Serialize, Deserialize, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct ChangeLeverageResponse {
+    pub leverage: u8,
+    #[serde(with = "string_or_float")]
+    pub max_notional_value: f64,
+    pub symbol: String,
+}
+
 fn default_stop_price() -> f64 { 0.0 }
 fn default_activation_price() -> f64 { 0.0 }
 fn default_price_rate() -> f64 { 0.0 }

--- a/src/model.rs
+++ b/src/model.rs
@@ -798,3 +798,34 @@ pub(crate) mod string_or_float {
         }
     }
 }
+
+pub(crate) mod string_or_float_opt {
+    use std::fmt;
+
+    use serde::{Serializer, Deserialize, Deserializer};
+
+    pub fn serialize<T, S>(value: &Option<T>, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        T: fmt::Display,
+        S: Serializer,
+    {
+        match value {
+            Some(v) => crate::model::string_or_float::serialize(v, serializer),
+            None => serializer.serialize_none()
+        }
+    }
+
+    pub fn deserialize<'de, D>(deserializer: D) -> Result<Option<f64>, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        #[derive(Deserialize)]
+        #[serde(untagged)]
+        enum StringOrFloat {
+            String(String),
+            Float(f64),
+        }
+
+        Ok(Some(crate::model::string_or_float::deserialize(deserializer)?))
+    }
+}

--- a/tests/futures_account_tests.rs
+++ b/tests/futures_account_tests.rs
@@ -1,0 +1,68 @@
+use binance::api::*;
+use binance::config::*;
+use binance::futures::account::*;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use mockito::{mock, Matcher};
+    use float_cmp::*;
+    
+    #[test]
+    fn change_initial_leverage() {
+        let mock_change_leverage = mock("POST", "/fapi/v1/leverage")
+            .with_header("content-type", "application/json;charset=UTF-8")
+            .match_query(Matcher::Regex("leverage=2&recvWindow=1234&symbol=LTCUSDT&timestamp=\\d+&signature=.*".into()))
+            .with_body_from_file("tests/mocks/futures/account/change_initial_leverage.json")
+            .create();
+        
+        let config = Config::default()
+            .set_futures_rest_api_endpoint(mockito::server_url())
+            .set_recv_window(1234);
+        let account: FuturesAccount = Binance::new_with_config(None, None, &config);
+        let _ = env_logger::try_init();
+        let response = account.change_initial_leverage("LTCUSDT", 2).unwrap();
+
+        mock_change_leverage.assert();
+
+        assert_eq!(response.leverage, 2);
+        assert_eq!(response.symbol, "LTCUSDT");
+        assert!(approx_eq!(f64, response.max_notional_value, 9223372036854776000.0, ulps = 2));
+    }
+
+    #[test]
+    fn cancel_all_open_orders() {
+        let mock = mock("DELETE", "/fapi/v1/allOpenOrders")
+            .with_header("content-type", "application/json;charset=UTF-8")
+            .match_query(Matcher::Regex("recvWindow=1234&symbol=BTCUSDT&timestamp=\\d+&signature=.*".into()))
+            .with_body_from_file("tests/mocks/futures/account/cancel_all_open_orders.json")
+            .create();
+        
+        let config = Config::default()
+            .set_futures_rest_api_endpoint(mockito::server_url())
+            .set_recv_window(1234);
+        let account: FuturesAccount = Binance::new_with_config(None, None, &config);
+        let _ = env_logger::try_init();
+        account.cancel_all_open_orders("BTCUSDT").unwrap();
+
+        mock.assert();
+    }
+
+    #[test]
+    fn change_position_mode() {
+        let mock = mock("POST", "/fapi/v1/positionSide/dual")
+            .with_header("content-type", "application/json;charset=UTF-8")
+            .match_query(Matcher::Regex("dualSidePosition=true&recvWindow=1234&timestamp=\\d+&signature=.*".into()))
+            .with_body_from_file("tests/mocks/futures/account/change_position_mode.json")
+            .create();
+        
+        let config = Config::default()
+            .set_futures_rest_api_endpoint(mockito::server_url())
+            .set_recv_window(1234);
+        let account: FuturesAccount = Binance::new_with_config(None, None, &config);
+        let _ = env_logger::try_init();
+        account.change_position_mode(true).unwrap();
+
+        mock.assert();
+    }
+}

--- a/tests/mocks/futures/account/cancel_all_open_orders.json
+++ b/tests/mocks/futures/account/cancel_all_open_orders.json
@@ -1,0 +1,4 @@
+{
+    "code": "200", 
+    "msg": "The operation of cancel all open order is done."
+}

--- a/tests/mocks/futures/account/change_initial_leverage.json
+++ b/tests/mocks/futures/account/change_initial_leverage.json
@@ -1,0 +1,5 @@
+{
+    "leverage": 2,
+    "maxNotionalValue": "9223372036854776000",
+    "symbol": "LTCUSDT"
+}

--- a/tests/mocks/futures/account/change_position_mode.json
+++ b/tests/mocks/futures/account/change_position_mode.json
@@ -1,0 +1,4 @@
+{
+    "code": 200,
+    "msg": "success"
+}


### PR DESCRIPTION
These are the fixes I proposed.
I also added the Change Initial Leverage Call (https://binance-docs.github.io/apidocs/futures/en/#change-initial-leverage-trade) and market order calls.

I tested both the leverage and limit order call. I did not test the market order, but am using very similar code in production.